### PR TITLE
Slightly more reliable way to remove --loglevel command-line option

### DIFF
--- a/mytardisfs/mytardisfs.py
+++ b/mytardisfs/mytardisfs.py
@@ -159,15 +159,14 @@ FUSE options:
         try:
             sys.argv.remove(opt + "=" + arg)
         except:
-            pass
-        try:
-            sys.argv.remove(opt + arg)
-        except:
-            pass
-        try:
-            sys.argv.remove(opt + " " + arg)
-        except:
-            pass
+            try:
+                sys.argv.remove(opt + arg)
+            except:
+                try:
+                    sys.argv.remove(opt)
+                    sys.argv.remove(arg)
+                except:
+                    pass
         if arg == 'ERROR':
             logger.setLevel(logging.ERROR)
             stream_handler.setLevel(logging.ERROR)


### PR DESCRIPTION
which is not compatible with FUSE. (By default, all MyTardsiFS
command-line options get passed onto FUSE.)
